### PR TITLE
fix: replace @ansvar/mcp-sqlite type import with better-sqlite3

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -4,7 +4,8 @@
  * Provides professional-use warnings, data freshness tracking, and source authority disclosure.
  */
 
-import type { Database } from '@ansvar/mcp-sqlite';
+import type BetterSqlite3 from 'better-sqlite3';
+type Database = BetterSqlite3.Database;
 
 export interface ResponseMetadata {
   /** Data freshness information */


### PR DESCRIPTION
## Summary
- Replaces `import type { Database } from '@ansvar/mcp-sqlite'` with `better-sqlite3` types
- `@ansvar/mcp-sqlite` was not in dependencies, causing TypeScript build failure during `npm publish`

## Test plan
- [x] `npm run build` passes
- [ ] `npm publish --dry-run` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)