### PR TITLE
feat: emit _meta envelope on watchdog-tested tools (Track A canary)

### DIFF
--- a/src/tools/shared-tools.ts
+++ b/src/tools/shared-tools.ts
@@ -6,6 +6,7 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 
 import { buildCitation } from '../citation.js';
+import { buildMeta } from '../utils/response-meta.js';
 import { about } from './about.js';
 import { checkCyberSanctions, type CheckCyberSanctionsInput } from './check-cyber-sanctions.js';
 import { checkDataFreshness, type CheckDataFreshnessInput } from './check-data-freshness.js';
@@ -190,7 +191,7 @@ export async function callTool(db: any, name: string, args: Record<string, unkno
   switch (name) {
     case 'search_sanctions_law': {
       const searchResults = await searchSanctionsLaw(db, args as unknown as SearchSanctionsLawInput);
-      return searchResults.map((r: any) => ({
+      const results = searchResults.map((r: any) => ({
         ...r,
         _citation: buildCitation(
           `${r.source_name ?? r.source_id} ${r.item_id}`,
@@ -200,6 +201,7 @@ export async function callTool(db: any, name: string, args: Record<string, unkno
           r.official_url || undefined,
         ),
       }));
+      return { results, count: results.length, _meta: buildMeta() };
     }
     case 'get_provision': {
       const provResult = await getProvision(db, args as unknown as GetProvisionInput);
@@ -301,10 +303,14 @@ export async function callTool(db: any, name: string, args: Record<string, unkno
         ),
       }));
     }
-    case 'list_sources':
-      return listSources(db, args as unknown as ListSourcesInput);
-    case 'about':
-      return about(db);
+    case 'list_sources': {
+      const sourcesResult = listSources(db, args as unknown as ListSourcesInput);
+      return { ...sourcesResult, _meta: buildMeta() };
+    }
+    case 'about': {
+      const aboutResult = about(db);
+      return { ...(aboutResult as object), _meta: buildMeta() };
+    }
     case 'check_data_freshness':
       return checkDataFreshness(db, args as unknown as CheckDataFreshnessInput);
     default:

--- a/src/utils/response-meta.ts
+++ b/src/utils/response-meta.ts
@@ -1,0 +1,37 @@
+/**
+ * Response envelope metadata (`_meta`) — conforms to Golden Standard §4.9b.
+ *
+ * Watchdog (scripts/mcp-watchdog.sh:~410) asserts:
+ *   - `_meta.disclaimer` is non-empty
+ *   - `_meta.data_age` matches ISO 8601 (YYYY-MM-DD...)
+ *
+ * This MCP is hand-built (not law-scaffold), so the `_meta` envelope is
+ * assembled at the dispatcher layer (tools/shared-tools.ts callTool) rather
+ * than inside each tool. Tools return their data-shaped result as-is;
+ * the dispatcher wraps watchdog-tested responses with `_meta`.
+ */
+
+export interface MetaEnvelope {
+  disclaimer: string;
+  data_age: string;
+  source_url?: string;
+  source_authority?: string;
+  jurisdiction?: string;
+}
+
+const DATA_AGE = '2026-02-27';
+
+const DISCLAIMER =
+  'Reference tool only. Not legal advice. Sanctions data changes frequently; verify against official government lists before acting.';
+
+const SOURCE_AUTHORITY =
+  'Official government sanctions portals: OFAC (Treasury.gov), EU Council (sanctionsmap.eu), UK OFSI (gov.uk), UN Security Council.';
+
+export function buildMeta(): MetaEnvelope {
+  return {
+    disclaimer: DISCLAIMER,
+    data_age: DATA_AGE,
+    source_authority: SOURCE_AUTHORITY,
+    jurisdiction: 'INTERNATIONAL',
+  };
+}


### PR DESCRIPTION
## Summary

Track A canary (hand-built domain MCP family) of the citation assertion rollout. The fleet manifest asserts `meta_present` on `tool-list` (list_sources) and `tool-search` (search_sanctions_law), but this MCP never emitted any envelope — tools returned data shapes directly.

Unlike law-scaffold MCPs (swedish-law canary) or envelope-renaming MCPs (latam canary), this hand-built MCP assembles `_meta` at the dispatcher layer, matching the codebase's existing `_citation` injection pattern.

## Changes

- `src/utils/response-meta.ts` (new) — local `buildMeta()` returning canonical `MetaEnvelope` shape.
- `src/tools/shared-tools.ts` (dispatcher):
  - `search_sanctions_law` — wraps array in `{ results, count, _meta }`. **Breaking shape change** (see below).
  - `list_sources`, `about` — spread existing object + add `_meta`.
- Other 9 tools not patched (not watchdog-asserted today). Follow-up can widen coverage.

## Breaking change

`search_sanctions_law` response was `Array<Result>` at the root; now it's `{ results: Array<Result>, count, _meta }`. Platform consumers that unwrap `.results` work fine; consumers that iterated the root array will need updating. This matches the fleet convention (every other `search_*` tool already returns `{ results, ... }`).

## Verification

- `tsc` clean.
- 104/104 tests pass.
- Watchdog `meta_present` — `_meta.disclaimer` non-empty + `_meta.data_age` ISO 8601 both satisfied.

## Test plan

- [ ] Merge, verify GHCR build.
- [ ] Watchtower picks up new image; confirm restart.
- [ ] Run `./scripts/mcp-watchdog.sh --repo sanctions-law`; confirm `tool-list` and `tool-search` flip to pass.
- [ ] Downstream consumer check: any callers of `search_sanctions_law` expecting array-at-root?

Refs:
- `docs/handover/2026-04-17-citation-assertion-results.md` §Track A
- Ansvar-Architecture-Documentation commit `2e9ecdf4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)